### PR TITLE
WIP: Acq test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,5 @@ target/
 # charm
 .idea/
 
-<<<<<<< HEAD
-
 # MacOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+doc/_build/
+
+# PyBuilder
+target/
+
+# charm
+.idea/
+
+<<<<<<< HEAD
+
+# MacOS
+.DS_Store

--- a/acq_test.py
+++ b/acq_test.py
@@ -1,0 +1,12 @@
+def acq_basic_test():
+    # import import
+    import_sample_info()
+    # test ct
+    xrun(0, 0)
+    # tsereis, 2s expo, 1s delay, 5 repeats
+    xrun(0, ScanPlan(bt, tseries, 2, 1, 5))
+    # Tramp, 2s expo, from 295k to 305k with 2k step
+    xrun(0, ScanPlan(bt, Tramp, 2, 295, 305, 2))
+    # Tlist 2s expo, 305k, 300k, 295k
+    xrun(0, ScanPlan(bt, Tlist, 2, [305, 300, 295]))
+


### PR DESCRIPTION
``acq`` related acceptance test at basic level. Feel free to add comments if needed. 

There are some pytest fixtures, such as ``bt, xrun, cs700`` and so on, have been set up in ``xpdacq``, please see [here](https://github.com/xpdAcq/xpdAcq/blob/master/xpdacq/tests/conftest.py)